### PR TITLE
Station distr check

### DIFF
--- a/src/targets/waveform/target.py
+++ b/src/targets/waveform/target.py
@@ -27,11 +27,13 @@ class StoreIDSelector(Object):
 
 
 class Crust2StoreIDSelector(StoreIDSelector):
-    template = String.T(help='template for gf store ID, for example crust2_${id}')
+    template = String.T(help='template for gf store ID,\
+                              for example crust2_${id}')
 
     def get_store_id(self, event, st, cha):
         s = Template(self.template)
-        return s.substitute(id=(crust2x2.get_profile(event.lat, event.lon)._ident).lower())
+        return s.substitute(id=(
+            crust2x2.get_profile(event.lat, event.lon)._ident).lower())
 
 
 class DomainChoice(StringChoice):
@@ -204,8 +206,6 @@ class WaveformTargetGroup(TargetGroup):
                 elif cha == 'Z':
                     target.azimuth = 0.
                     target.dip = -90.
-
-
 
                 target.set_dataset(ds)
                 targets.append(target)

--- a/src/targets/waveform/target.py
+++ b/src/targets/waveform/target.py
@@ -40,13 +40,12 @@ class StationDictStoreIDSelector(StoreIDSelector):
     dict_st_gfid = Dict.T(help='Dictionary with station-gfdb pairs')
 
     def get_store_id(self, event, st, cha):
-        try: 
+        try:
             store_id = self.dict_st_gfid['%s.%s' % (st.network, st.station)]
         except KeyError:
             store_id = self.dict_st_gfid['others']
 
         return store_id
-
 
 
 class StationDistrReq(Object):

--- a/src/targets/waveform/target.py
+++ b/src/targets/waveform/target.py
@@ -27,7 +27,7 @@ class StoreIDSelector(Object):
 
 
 class Crust2StoreIDSelector(StoreIDSelector):
-    template = String.T(help='template for gf store ID')
+    template = String.T(help='template for gf store ID, for example crust2_${id}')
 
     def get_store_id(self, event, st, cha):
         s = Template(self.template)

--- a/src/targets/waveform/target.py
+++ b/src/targets/waveform/target.py
@@ -14,6 +14,9 @@ from grond.dataset import NotFound
 from ..base import (MisfitConfig, MisfitTarget, MisfitResult, TargetGroup)
 from grond.meta import has_get_plot_classes
 
+from pyrocko import crust2x2
+
+
 guts_prefix = 'grond'
 logger = logging.getLogger('grond.targets.waveform.target')
 
@@ -23,9 +26,10 @@ class StoreIDSelector(Object):
 
 
 class Crust2StoreIDSelector(StoreIDSelector):
-    template = String.T()  # 'crust2_${id}_hf'
+    template = String.T()
 
-    pass
+    def get_store_id(self, event, st, cha):
+        return self.template % str.lower(crust2x2.get_profile(event.lat, event.lon)._ident)
 
 
 class DomainChoice(StringChoice):

--- a/src/targets/waveform/target.py
+++ b/src/targets/waveform/target.py
@@ -15,6 +15,7 @@ from ..base import (MisfitConfig, MisfitTarget, MisfitResult, TargetGroup)
 from grond.meta import has_get_plot_classes
 
 from pyrocko import crust2x2
+from string import Template
 
 
 guts_prefix = 'grond'
@@ -26,10 +27,11 @@ class StoreIDSelector(Object):
 
 
 class Crust2StoreIDSelector(StoreIDSelector):
-    template = String.T()
+    template = String.T(help='template for gf store ID')
 
     def get_store_id(self, event, st, cha):
-        return self.template % str.lower(crust2x2.get_profile(event.lat, event.lon)._ident)
+        s = Template(self.template)
+        return s.substitute(id=(crust2x2.get_profile(event.lat, event.lon)._ident).lower())
 
 
 class DomainChoice(StringChoice):


### PR DESCRIPTION
2 independent new methods:
(1a) Selection of gfdb based on crust2x2 model and event location
(1b) Selection of gfdb based on a station dictionary provided in the config file
(2) Extension of check_problem() by a minimum number of station and a minimum azimuthal coverage of stations that can be defined in the config file. Check_problem can now also handle grond errors in one run without aborting all parallel runs. errors are summarised after finishing all runs.