### PR TITLE
bugfix: StationDistributionPlot for gnss_campaign targets.

### DIFF
--- a/src/targets/gnss_campaign/plot.py
+++ b/src/targets/gnss_campaign/plot.py
@@ -258,12 +258,20 @@ components).
             target.set_dataset(dataset)
             comp_weights = target.component_weights()[0]
 
-            ws_n = comp_weights[:, 0::3] / comp_weights.max()
-            ws_e = comp_weights[:, 1::3] / comp_weights.max()
-            ws_u = comp_weights[:, 2::3] / comp_weights.max()
-            ws_e = num.array(ws_e[0]).flatten()
-            ws_n = num.array(ws_n[0]).flatten()
-            ws_u = num.array(ws_u[0]).flatten()
+            comp_weights = comp_weights.A1
+            mask=target.station_component_mask
+            ws_all=num.empty(mask.shape)
+            i=0
+            for x in range(len(mask)):
+                if mask[x]==True:
+                    ws_all[x]=comp_weights[i]/ comp_weights.max()
+                    i+=1
+                else:
+                    ws_all[x]=num.nan
+
+            ws_n = ws_all[0::3]
+            ws_e = ws_all[1::3]
+            ws_u = ws_all[2::3]
 
             if ws_n.size == 0:
                 continue
@@ -296,7 +304,6 @@ components).
             legend.set_title('Weight, U components')
 
             yield (item, fig)
-
 
 def get_plot_classes():
     return [


### PR DESCRIPTION
Enables plotting of StationDistributionPlot for less then three available gnss components.
Previous version did not consider missing gnss components. Hence there was an error message in the report creation, which is now fixed.